### PR TITLE
feat: [NS] create report button in video OSD

### DIFF
--- a/src/controllers/playback/video/index.html
+++ b/src/controllers/playback/video/index.html
@@ -87,6 +87,9 @@
                 <button is="paper-icon-button-light" class="btnVideoOsdSettings autoSize" title="${Settings}">
                     <span class="largePaperIconButton material-icons settings" aria-hidden="true"></span>
                 </button>
+                <button is="paper-icon-button-light" class="btnReportBadMedia hide autoSize" title="${ReportBadMedia}">
+                    <span class="xlargePaperIconButton material-icons report_problem" aria-hidden="true"></span>
+                </button>
                 <button is="paper-icon-button-light" class="btnAirPlay hide autoSize" title="${AirPlay}">
                     <span class="xlargePaperIconButton material-icons airplay" aria-hidden="true"></span>
                 </button>

--- a/src/controllers/playback/video/index.js
+++ b/src/controllers/playback/video/index.js
@@ -29,6 +29,8 @@ import shell from '../../../scripts/shell';
 import SubtitleSync from '../../../components/subtitlesync/subtitlesync';
 import { appRouter } from '../../../components/router/appRouter';
 import { ServerConnections } from 'lib/jellyfin-apiclient';
+import confirm from '../../../components/confirm/confirm';
+import toast from '../../../components/toast/toast';
 import LibraryMenu from '../../../scripts/libraryMenu';
 import { setBackdropTransparency, TRANSPARENCY_LEVEL } from '../../../components/backdrop/backdrop';
 import { pluginManager } from '../../../components/pluginManager';
@@ -198,6 +200,7 @@ export default function (view) {
             btnRewind.disabled = true;
             view.querySelector('.btnSubtitles').classList.add('hide');
             view.querySelector('.btnAudio').classList.add('hide');
+            view.querySelector('.btnReportBadMedia')?.classList.add('hide');
             view.querySelector('.osdTitle').innerHTML = '';
             view.querySelector('.osdMediaInfo').innerHTML = '';
             return;
@@ -224,6 +227,9 @@ export default function (view) {
             view.querySelector('.btnAudio').classList.add('hide');
         }
 
+        // Always show report button when a playable item is loaded
+        view.querySelector('.btnReportBadMedia')?.classList.remove('hide');
+
         if (currentItem.Chapters?.length > 1) {
             view.querySelector('.btnPreviousChapter').classList.remove('hide');
             view.querySelector('.btnNextChapter').classList.remove('hide');
@@ -231,6 +237,39 @@ export default function (view) {
             view.querySelector('.btnPreviousChapter').classList.add('hide');
             view.querySelector('.btnNextChapter').classList.add('hide');
         }
+    }
+
+    function onReportBadMediaClick() {
+        const item = currentItem;
+        if (!item || !item.Id) return;
+
+        const title = globalize.translate('HeaderReportBadMedia');
+        const text = globalize.translate('MessageConfirmReportBadMedia');
+        const confirmText = globalize.translate('ButtonReport');
+
+        confirm({ title, text, confirmText })
+            .then(() => {
+                const apiClient = ServerConnections.getApiClient(item.ServerId);
+                const url = apiClient.getUrl('Profixer/Report');
+                return apiClient.ajax({
+                    type: 'POST',
+                    url,
+                    data: JSON.stringify({ ItemId: item.Id }),
+                    contentType: 'application/json'
+                });
+            })
+            .then(() => {
+                toast(globalize.translate('MessageReportSubmitted'));
+            })
+            .catch(err => {
+                // Ignore rejection from confirm dialog (click outside or Cancel)
+                if (!err || err.message === 'Confirm dialog rejected') return;
+                console.error('[VideoOSD] Failed to report bad media', err);
+                toast(globalize.translate('MessageReportFailed'));
+            })
+            .finally(() => {
+                resetIdle();
+            });
     }
 
     function setTitle(item, parentName) {
@@ -1776,6 +1815,7 @@ export default function (view) {
         playbackManager.toggleAirPlay(currentPlayer);
     });
     view.querySelector('.btnVideoOsdSettings').addEventListener('click', onSettingsButtonClick);
+    view.querySelector('.btnReportBadMedia').addEventListener('click', onReportBadMediaClick);
     view.addEventListener('viewhide', function () {
         headerElement.classList.remove('hide');
     });
@@ -2070,4 +2110,3 @@ export default function (view) {
         });
     }
 }
-

--- a/src/strings/en-gb.json
+++ b/src/strings/en-gb.json
@@ -2069,5 +2069,11 @@
     "LabelBackupsUnavailable": "No backups available",
     "MessageServerMismatch": "The server you are connecting to is not the same server that you previously connected to at this address. If this is expected, please select \"Connect Anyway\". Otherwise, your connection or the server might be compromised.",
     "ConfirmDeleteRepository": "Delete repository?",
-    "DeleteRepositoryConfirmation": "Are you sure you want to delete this repository?"
+    "DeleteRepositoryConfirmation": "Are you sure you want to delete this repository?",
+    "MessageConfirmReportBadMedia": "Report a problem for this media and trigger a new download?",
+    "MessageReportSubmitted": "Report submitted.",
+    "MessageReportFailed": "Failed to submit report.",
+    "ReportBadMedia": "Report bad media",
+    "HeaderReportBadMedia": "Report Bad Media",
+    "ButtonReport": "Report"
 }

--- a/src/strings/en-us.json
+++ b/src/strings/en-us.json
@@ -1868,5 +1868,11 @@
     "ExtractTrickplayImagesHelp": "Trickplay images are similar to chapter images, except they span the entire length of the content and are used to show a preview when scrubbing through videos.",
     "LabelExtractTrickplayDuringLibraryScan": "Extract trickplay images during the library scan",
     "LabelExtractTrickplayDuringLibraryScanHelp": "Generate trickplay images when videos are imported during the library scan. Otherwise, they will be extracted during the trickplay images scheduled task. If generation is set to non-blocking this will not affect the time a library scan takes to complete.",
-    "LogLoadFailure": "Failed to load the log file. It may still be actively written to."
+    "LogLoadFailure": "Failed to load the log file. It may still be actively written to.",
+    "MessageConfirmReportBadMedia": "Report a problem for this media and trigger a new download?",
+    "MessageReportSubmitted": "Report submitted.",
+    "MessageReportFailed": "Failed to submit report.",
+    "ReportBadMedia": "Report bad media",
+    "HeaderReportBadMedia": "Report Bad Media",
+    "ButtonReport": "Report"
 }

--- a/src/strings/fr-ca.json
+++ b/src/strings/fr-ca.json
@@ -2013,5 +2013,11 @@
     "LabelAvailable": "Disponible",
     "LabelBundled": "Groupé",
     "ManageRepositories": "Gérer les dépôts",
-    "ViewAllPlugins": "Voir tous les plugiciels"
+    "ViewAllPlugins": "Voir tous les plugiciels",
+    "MessageConfirmReportBadMedia": "Signaler un problème pour ce média et déclencher un nouveau téléchargement?",
+    "MessageReportSubmitted": "Rapport soumis.",
+    "MessageReportFailed": "Échec de la soumission du rapport.",
+    "ReportBadMedia": "Signaler un mauvais média",
+    "HeaderReportBadMedia": "Signaler un mauvais média",
+    "ButtonReport": "Signaler"
 }

--- a/src/strings/fr.json
+++ b/src/strings/fr.json
@@ -2069,5 +2069,11 @@
     "LabelAvailable": "Disponible",
     "LabelBundled": "Groupé",
     "ManageRepositories": "Gérer les dépôts",
-    "ViewAllPlugins": "Voir tous les plugins"
+    "ViewAllPlugins": "Voir tous les plugins",
+    "MessageConfirmReportBadMedia": "Signaler un problème pour ce média et déclencher un nouveau téléchargement?",
+    "MessageReportSubmitted": "Rapport soumis.",
+    "MessageReportFailed": "Échec de la soumission du rapport.",
+    "ReportBadMedia": "Signaler un mauvais média",
+    "HeaderReportBadMedia": "Signaler un mauvais média",
+    "ButtonReport": "Signaler"
 }


### PR DESCRIPTION
This PR adds a “Report Bad Media” button to the Jellyfin video player OSD that lets users report problematic media and trigger a redownload via the Jellyfin backend.

## What’s Included

- Video OSD button
    - New button in the video OSD with icon report_problem.
    - Hidden by default; shown whenever a playable item is loaded.
- Confirm + API request
    - Shows a confirmation dialog before reporting.
    - On confirm, sends a POST request to /Profixer/Report with JSON body { "ItemId": "<current item id>" }.
    - Success and error toasts shown accordingly.
    - Cancel/dismiss is handled correctly (no request, no error toast).
- Localizations
    - New keys are added for the new button in English and French

## Implementation Details

- Endpoint
    - URL: /Profixer/Report
    - Method: POST
    - Body: { "ItemId": "<current item id>" }
    - Content-Type: application/json
- Behavior
    - The report button is shown when a NowPlayingItem exists and hidden when nothing is playing.
    - Confirm dialog rejects cleanly on cancel or outside‑click; the code ignores these cases to avoid false error toasts.
    - Success → toast “Report submitted.”
    - Failure → toast “Failed to submit report.”

## How to Test

- Play a video to open the Video OSD.
- Click the “Report bad media” icon (tooltip uses localized text).
- Confirm in the dialog:
    - Observe a POST to /Profixer/Report with JSON { "ItemId": "<id>" }.
    - Success toast: “Report submitted.”
- Cancel/dismiss the dialog:
    - No request should be sent.
    - No error toast should appear.